### PR TITLE
Implemented `getUserData` to return the user array when given user name.

### DIFF
--- a/auth.php
+++ b/auth.php
@@ -24,6 +24,16 @@ class auth_plugin_authgoogle extends auth_plugin_authplain  {
         $this->cando['external'] = true;
         $this->cando['logout'] = true; 
     }
+
+    public function getUserData($user) {
+        if($this->users === null) $this->_loadUserData();
+        foreach ($this->users as $key=>$val){
+            if (is_array($val) && $val['name'] === $user){
+                return $val;
+            }
+        }
+        return false;
+    }
     
     function trustExternal($user, $pass, $sticky = false) {
 	global $USERINFO, $ID;


### PR DESCRIPTION
When I started using `dokuwiki-authorlist` plugin I noticed that the emails of authors aren't linked.

This is because with plain auth user ID and user name is the same, so passing in user name as parameter successfully retrieves the user from the array as it maps with the keys using user ID.

However with Google auth ID is different from name, so in order to be able to get user data (using meta/contributors for example) we need to loop through the array and look the user up by name.
