### PR TITLE
Link to social_google_box.png is broken when doku is installed in subfolder.

### DIFF
--- a/action.php
+++ b/action.php
@@ -54,7 +54,7 @@ class action_plugin_authgoogle extends DokuWiki_Action_Plugin {
             
             $a_style = "width: 200px;margin:0 auto;color: #666666;cursor: pointer;text-decoration: none !important;display: block;padding-bottom:1.4em;";//-moz-linear-gradient(center top , #F8F8F8, #ECECEC)
             $div_style = "float:left;line-height: 30px;background-color: #F8F8F8;border: 1px solid #C6C6C6;border-radius: 2px 2px 2px 2px;padding: 0px 5px 0px 5px;position: relative;";
-            $img_style = "width:20px;height:20px;margin:5px 5px 5px 0;background: url('/lib/plugins/authgoogle/images/social_google_box.png') no-repeat;float:left;";
+            $img_style = "width:20px;height:20px;margin:5px 5px 5px 0;background: url('".wl("lib/plugins/authgoogle/images/social_google_box.png")."') no-repeat;float:left;";
             echo "<a href='$auth_url' style='$a_style' title='".$this->getLang('enter_google')."'><div style=\"$div_style\"><div style=\"$img_style\"></div>".$this->getLang('enter_google')."</div>";
             echo "<div style='clear: both;'></div></a>";
         }


### PR DESCRIPTION
My dokuwiki is installed in `http://<domain>/wiki/` and the plugin was improperly linking to `/lib/plugins/authgoogle/images/social_google_box.png`.
I added a call to the `wl()` function to use the proper target url.
