### PR TITLE
Redirect to desired page after login/reauth.

### DIFF
--- a/auth.php
+++ b/auth.php
@@ -67,6 +67,11 @@ class auth_plugin_authgoogle extends auth_plugin_authplain  {
             $_SESSION[DOKU_COOKIE]['authgoogle']['token'] = $_COOKIE[AUTHGOOGLE_COOKIE];
         }
 
+	//set our referer for redirection, if we're hitting login
+	if (!empty($_SERVER['HTTP_REFERER']) {
+		$_SESSION[DOKU_COOKIE]['authgoogle']['referer'] = $_SERVER['HTTP_REFERER'];
+	}
+
         //google auth
         require_once GOOGLE_API_DIR.'/Google_Client.php';
         require_once GOOGLE_API_DIR.'/contrib/Google_Oauth2Service.php';
@@ -169,9 +174,12 @@ class auth_plugin_authgoogle extends auth_plugin_authplain  {
             // update token
             $_SESSION['token'] = $client->getAccessToken();
 
-            //if login page - redirect to main page
-            if (isset($_GET['do']) && $_GET['do']=='login')
-                header("Location: ".wl('start', '', true));
+            //if login page - redirect to original referer or, if none, start page.
+            if (isset($_GET['do']) && $_GET['do']=='login') {
+		$referer = $_SESSION[DOKU_COOKIE]['authgoogle']['referer'];
+	    	$redirect = empty($referer) ? wl('start', '', true) : $referer;
+		header("Location: ".$referer);
+	    }
 
             return true;
         } else {

--- a/auth.php
+++ b/auth.php
@@ -68,7 +68,7 @@ class auth_plugin_authgoogle extends auth_plugin_authplain  {
         }
 
 	//set our referer for redirection, if we're hitting login
-	if (!empty($_SERVER['HTTP_REFERER']) {
+	if (!empty($_SERVER['HTTP_REFERER'])) {
 		$_SESSION[DOKU_COOKIE]['authgoogle']['referer'] = $_SERVER['HTTP_REFERER'];
 	}
 
@@ -118,13 +118,13 @@ class auth_plugin_authgoogle extends auth_plugin_authplain  {
 
         //if successed auth
         if ($client->getAccessToken()) {
-            
+
             // If the access token is expired, ask the user to login again
             if($client->isAccessTokenExpired()) {
                 $authUrl = $client->createAuthUrl();
                 header('Location: ' . filter_var($authUrl, FILTER_SANITIZE_URL));
             }
-            
+
             $user = $oauth2->userinfo->get();
             $email = filter_var($user['email'], FILTER_SANITIZE_EMAIL);
             //$img = filter_var($user['picture'], FILTER_VALIDATE_URL);


### PR DESCRIPTION
Currently, if a user clicks on a link into a Dokuwiki using this plugin and they're not logged in, they're forced to the `start` route after login. This means the user needs to click the link, then log in, then go back and click the link again to get to their intended destination. 

This patch corrects this by persisting the referer from our login page so that users are redirected to their intended destination after logging in. 

Been a while since I PHP'ed - comments/criticism welcome. :) Thanks for this plugin!
