### PR TITLE
Fix for Issues #42 and part of issue #38

### DIFF
--- a/action.php
+++ b/action.php
@@ -8,7 +8,7 @@ class action_plugin_authgoogle extends DokuWiki_Action_Plugin {
     /**
      * Registers the event handlers.
      */
-    function register(&$controller)
+    function register(function register(Doku_Event_Handler $controller))
     {
         $controller->register_hook('HTML_LOGINFORM_OUTPUT', 'BEFORE',  $this, 'hook_html_loginform_output', array());
         $controller->register_hook('HTML_UPDATEPROFILEFORM_OUTPUT', 'BEFORE', $this, 'hook_updateprofileform_output', array());


### PR DESCRIPTION
Specifically: Warning: Declaration of action_plugin_authgoogle::register(&$controller) should be compatible with DokuWiki_Action_Plugin::register(Doku_Event_Handler $controller) in /var/www/html/lib/plugins/authgoogle/action.php on line 7